### PR TITLE
Setup for Etherscan verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# vim
+*.swp
+*.swo

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -2,10 +2,24 @@ import 'hardhat-gas-reporter'
 import 'tsconfig-paths/register'
 import 'solidity-coverage'
 import '@nomiclabs/hardhat-ethers'
+import '@nomiclabs/hardhat-etherscan'
 import '@openzeppelin/hardhat-upgrades'
 import { task } from 'hardhat/config'
 import { config as dotenvConfig } from 'dotenv'
 import { resolve } from 'path'
+
+dotenvConfig({ path: resolve(__dirname, "./.env.local") });
+
+// Ensure that we have all the environment variables we need.
+const mnemonic: string | undefined = process.env.MNEMONIC;
+if (!mnemonic) {
+  throw new Error("MNEMONIC env var needs to be set.");
+}
+
+const infuraApiKey: string | undefined = process.env.INFURA_API_KEY;
+if (!infuraApiKey) {
+  throw new Error("INFURA_API_KEY needs to be set.");
+}
 
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://hardhat.org/guides/create-task.html
@@ -17,6 +31,7 @@ task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
   }
 })
 
+
 // You need to export an object to set up your config
 // Go to https://hardhat.org/config/ to learn more
 
@@ -25,4 +40,27 @@ task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
  */
 module.exports = {
   solidity: '0.8.7',
+  networks: {
+    mainnet: {
+      url: "https://mainnet.infura.io/v3/" + infuraApiKey,
+      accounts: {
+        mnemonic,
+      },
+    },
+    kovan: {
+      url: "https://kovan.infura.io/v3/" + infuraApiKey,
+      accounts: {
+        mnemonic,
+      },
+    },
+    rinkeby: {
+      url: "https://rinkeby.infura.io/v3/" + infuraApiKey,
+      accounts: {
+        mnemonic,
+      },
+    },
+  },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY,
+  },
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
+    "@nomiclabs/hardhat-etherscan": "^2.1.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/cli": "^2.8.2",
     "@openzeppelin/contracts-ethereum-package": "^3.0.0",

--- a/scripts/hardhat/deploy.ts
+++ b/scripts/hardhat/deploy.ts
@@ -3,30 +3,34 @@
 //
 // When running the script with `npx hardhat run <script>` you'll find the Hardhat
 // Runtime Environment's members available in the global scope.
-import { ethers } from 'hardhat'
+import hre from "hardhat";
+import { ethers, network } from "hardhat";
 
 async function main() {
-  // Hardhat always runs the compile task when running scripts with its command
-  // line interface.
-  //
-  // If this script is run directly using `node` you may want to call compile
-  // manually to make sure everything is compiled
-  // await hre.run('compile');
+  await hre.run("compile");
+  const networkName = network.name.toUpperCase();
+  console.log("");
+  console.log(`${networkName} selected`);
+  console.log("");
 
-  // We get the contract to deploy
-  const Greeter = await ethers.getContractFactory('Greeter')
-  const greeter = await Greeter.deploy('Hello, Hardhat!')
+  const [deployer] = await ethers.getSigners();
 
-  await greeter.deployed()
-
-  console.log('Greeter deployed to:', greeter.address)
+  const ActionNFT = await ethers.getContractFactory('ActionNFT');
+  const nft = await ActionNFT.deploy(deployer.address, "10000000000000000");
+  const txHash = nft.deployTransaction.hash;
+  console.log(`https://${networkName.toLowerCase()}.etherscan.io/tx/${txHash}`);
+  await nft.deployed();
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main()
-  .then(() => process.exit(0))
+  .then(() => {
+    console.log("Deployment successful.");
+    console.log("");
+    process.exit(0);
+  })
   .catch(error => {
-    console.error(error)
-    process.exit(1)
+    console.error(error);
+    process.exit(1);
   })


### PR DESCRIPTION
I added the `hardhat-etherscan` plugin to the hardhat config and `package.json`.  Took the opportunity to add some networks in the config.  I know different folks have different ways of handling env vars; I chose what seemed the easiest/economical for us at the moment.  

I wasn't able to update the `package-lock.json` due to one of the deps being linux-based.  Someone else will have to update that, but I don't believe this will cause an issue.

Due to some peculiarities of Etherscan verification, we should deploy through hardhat also to avoid problems.  I've updated the sample hardhat deploy to actually deploy the Action NFT.  

Here are the steps to follow:

- deploy: `npx hardhat --network <network name> run scripts/hardhat/deploy.ts`\
  `<network name>` can be `rinkeby`, `kovan`, or `mainnet`
- verify: `npx hardhat verify --network <network name> <contract address> "<deployer address>" "10000000000000000"`\
  `<contract address>` is the deployed contract address
  `<deployer address>` is the account 0 of the mnemonic you are using
  These can be easily copied-and-pasted from the etherscan link, which will be console-logged by the deploy script.